### PR TITLE
Fix iOS: Swift args out of bounds NS Exception

### DIFF
--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -268,29 +268,33 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 - (void) ids:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{
-        int code                 = [command.arguments[0] intValue];
-        APPNotificationType type = NotifcationTypeUnknown;
+        
+        if (command.arguments.count != 0) {
+            
+            int code                 = [command.arguments[0] intValue];
+            APPNotificationType type = NotifcationTypeUnknown;
 
-        switch (code) {
-            case 0:
-                type = NotifcationTypeAll;
-                break;
-            case 1:
-                type = NotifcationTypeScheduled;
-                break;
-            case 2:
-                type = NotifcationTypeTriggered;
-                break;
+            switch (code) {
+                case 0:
+                    type = NotifcationTypeAll;
+                    break;
+                case 1:
+                    type = NotifcationTypeScheduled;
+                    break;
+                case 2:
+                    type = NotifcationTypeTriggered;
+                    break;
+            }
+
+            NSArray* ids = [_center getNotificationIdsByType:type];
+
+            CDVPluginResult* result;
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                        messageAsArray:ids];
+
+            [self.commandDelegate sendPluginResult:result
+                                        callbackId:command.callbackId];
         }
-
-        NSArray* ids = [_center getNotificationIdsByType:type];
-
-        CDVPluginResult* result;
-        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                    messageAsArray:ids];
-
-        [self.commandDelegate sendPluginResult:result
-                                    callbackId:command.callbackId];
     }];
 }
 
@@ -328,37 +332,39 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 - (void) notifications:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{
-        int code                 = [command.arguments[0] intValue];
-        APPNotificationType type = NotifcationTypeUnknown;
-        NSArray* toasts;
-        NSArray* ids;
+        if (command.arguments.count != 0) {
+            int code                 = [command.arguments[0] intValue];
+            APPNotificationType type = NotifcationTypeUnknown;
+            NSArray* toasts;
+            NSArray* ids;
 
-        switch (code) {
-            case 0:
-                type = NotifcationTypeAll;
-                break;
-            case 1:
-                type = NotifcationTypeScheduled;
-                break;
-            case 2:
-                type = NotifcationTypeTriggered;
-                break;
-            case 3:
-                ids    = command.arguments[1];
-                toasts = [_center getNotificationOptionsById:ids];
-                break;
+            switch (code) {
+                case 0:
+                    type = NotifcationTypeAll;
+                    break;
+                case 1:
+                    type = NotifcationTypeScheduled;
+                    break;
+                case 2:
+                    type = NotifcationTypeTriggered;
+                    break;
+                case 3:
+                    ids    = command.arguments[1];
+                    toasts = [_center getNotificationOptionsById:ids];
+                    break;
+            }
+
+            if (toasts == nil) {
+                toasts = [_center getNotificationOptionsByType:type];
+            }
+
+            CDVPluginResult* result;
+            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                        messageAsArray:toasts];
+
+            [self.commandDelegate sendPluginResult:result
+                                        callbackId:command.callbackId];
         }
-
-        if (toasts == nil) {
-            toasts = [_center getNotificationOptionsByType:type];
-        }
-
-        CDVPluginResult* result;
-        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                    messageAsArray:toasts];
-
-        [self.commandDelegate sendPluginResult:result
-                                    callbackId:command.callbackId];
     }];
 }
 
@@ -401,26 +407,28 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 - (void) actions:(CDVInvokedUrlCommand *)command
 {
     [self.commandDelegate runInBackground:^{
-        int code             = [command.arguments[0] intValue];
-        NSString* identifier = [command argumentAtIndex:1];
-        NSArray* actions     = [command argumentAtIndex:2];
-        UNNotificationCategory* group;
-        BOOL found;
+        if (command.arguments.count != 0) {
+            int code             = [command.arguments[0] intValue];
+            NSString* identifier = [command argumentAtIndex:1];
+            NSArray* actions     = [command argumentAtIndex:2];
+            UNNotificationCategory* group;
+            BOOL found;
 
-        switch (code) {
-            case 0:
-                group = [APPNotificationCategory parse:actions withId:identifier];
-                [_center addActionGroup:group];
-                [self execCallback:command];
-                break;
-            case 1:
-                [_center removeActionGroup:identifier];
-                [self execCallback:command];
-                break;
-            case 2:
-                found = [_center hasActionGroup:identifier];
-                [self execCallback:command arg:found];
-                break;
+            switch (code) {
+                case 0:
+                    group = [APPNotificationCategory parse:actions withId:identifier];
+                    [_center addActionGroup:group];
+                    [self execCallback:command];
+                    break;
+                case 1:
+                    [_center removeActionGroup:identifier];
+                    [self execCallback:command];
+                    break;
+                case 2:
+                    found = [_center hasActionGroup:identifier];
+                    [self execCallback:command arg:found];
+                    break;
+            }
         }
     }];
 }

--- a/src/ios/APPLocalNotification.m
+++ b/src/ios/APPLocalNotification.m
@@ -269,10 +269,12 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 {
     [self.commandDelegate runInBackground:^{
         
+        APPNotificationType type = NotifcationTypeUnknown;
+        
         if (command.arguments.count != 0) {
             
-            int code                 = [command.arguments[0] intValue];
-            APPNotificationType type = NotifcationTypeUnknown;
+            int code = [command.arguments[0] intValue];
+            
 
             switch (code) {
                 case 0:
@@ -285,16 +287,15 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
                     type = NotifcationTypeTriggered;
                     break;
             }
-
-            NSArray* ids = [_center getNotificationIdsByType:type];
-
-            CDVPluginResult* result;
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                        messageAsArray:ids];
-
-            [self.commandDelegate sendPluginResult:result
-                                        callbackId:command.callbackId];
         }
+        NSArray* ids = [_center getNotificationIdsByType:type];
+
+        CDVPluginResult* result;
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                    messageAsArray:ids];
+
+        [self.commandDelegate sendPluginResult:result
+                                    callbackId:command.callbackId];
     }];
 }
 
@@ -332,11 +333,16 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
 - (void) notifications:(CDVInvokedUrlCommand*)command
 {
     [self.commandDelegate runInBackground:^{
+        
+        APPNotificationType type = NotifcationTypeUnknown;
+        
+        NSArray* toasts;
+        NSArray* ids;
+        
         if (command.arguments.count != 0) {
             int code                 = [command.arguments[0] intValue];
-            APPNotificationType type = NotifcationTypeUnknown;
-            NSArray* toasts;
-            NSArray* ids;
+            
+
 
             switch (code) {
                 case 0:
@@ -353,18 +359,19 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
                     toasts = [_center getNotificationOptionsById:ids];
                     break;
             }
-
-            if (toasts == nil) {
-                toasts = [_center getNotificationOptionsByType:type];
-            }
-
-            CDVPluginResult* result;
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
-                                        messageAsArray:toasts];
-
-            [self.commandDelegate sendPluginResult:result
-                                        callbackId:command.callbackId];
         }
+
+        if (toasts == nil) {
+            toasts = [_center getNotificationOptionsByType:type];
+        }
+
+        CDVPluginResult* result;
+        result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK
+                                    messageAsArray:toasts];
+
+        [self.commandDelegate sendPluginResult:result
+                                    callbackId:command.callbackId];
+
     }];
 }
 
@@ -429,6 +436,8 @@ UNNotificationPresentationOptions const OptionAlert = UNNotificationPresentation
                     [self execCallback:command arg:found];
                     break;
             }
+        } else {
+            [self execCallback:command];
         }
     }];
 }


### PR DESCRIPTION
This fixes a use case where functions in the cordova plugin would yield out of bounds exception when called, such as getAll. Works without issues on Android.