### PR TITLE
[JOY-17243] [Android] [Crash] Fatal Exception: java.lang.RuntimeException

### DIFF
--- a/src/android/notification/Builder.java
+++ b/src/android/notification/Builder.java
@@ -203,7 +203,7 @@ public final class Builder {
 
         int reqCode = random.nextInt();
         // request code and flags not added for demo purposes
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, reqCode, intent, FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, reqCode, intent, FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         builder.setFullScreenIntent(pendingIntent, true);
     }

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -316,7 +316,7 @@ public final class Notification {
             Intent intent = new Intent(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, 0 | PendingIntent.FLAG_IMMUTABLE);
+                    context, 0, intent, 0 | PendingIntent.FLAG_MUTABLE);
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);

--- a/src/android/notification/Notification.java
+++ b/src/android/notification/Notification.java
@@ -316,7 +316,7 @@ public final class Notification {
             Intent intent = new Intent(action);
 
             PendingIntent pi = PendingIntent.getBroadcast(
-                    context, 0, intent, 0 | PendingIntent.FLAG_MUTABLE);
+                    context, 0, intent, 0 | PendingIntent.FLAG_IMMUTABLE);
 
             if (pi != null) {
                 getAlarmMgr().cancel(pi);


### PR DESCRIPTION
## Ticket

This fixes [JOY-17243](https://jira.ableto.com/browse/JOY-17243)

This issue was introduced with the recent update of the plugin - https://github.com/sanvello/cordova-plugin-local-notifications/pull/6.

Previously all `PendingIntent`s had a mutability flag set in order to meet -https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability - but the recent update added a new `PendingIntent` that's missing the flag. 